### PR TITLE
Add basic makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Makefile,*.mk}]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Binaries for this project
+tfe-cli-*
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+TARGET_NAME := tfe-cli
+PLATFORMS := linux-amd64 darwin-amd64 windows-amd64
+TARGET_NAME_PLATFORM := $(foreach platform,$(PLATFORMS),$(TARGET_NAME)-$(platform))
+
+os_arch_split = $(subst -, ,$@)
+os = $(word 3, $(os_arch_split))
+arch = $(word 4, $(os_arch_split))
+
+.PHONY: clean
+clean:
+	rm $(TARGET_NAME_PLATFORM)
+
+release: $(TARGET_NAME_PLATFORM)
+
+$(TARGET_NAME_PLATFORM):
+	GOOS=$(os) GOARCH=$(arch) go build -o '$@'

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Types of changes
----------------
- Infrastructure and automation

Description
-----------
Add a basic Makefile with cross-platform compiler support.

Building all binaries allows for faster creation of Linux, Windows, and macOS binaries for testing and release.

Checklist:
----------
N/A

- [x] I have updated the documentation accordingly
- [x] I have updated the Changelog (if applicable)
