### PR TITLE
Support TFE_ADDRESS and TFE_BASEPATH env variables

### DIFF
--- a/tfecli/core.go
+++ b/tfecli/core.go
@@ -38,9 +38,16 @@ func getToken(cmd *cobra.Command) (string, error) {
 
 // NewClient prepares a TFE client.
 func newClient(token string) (*tfe.Client, error) {
+
+	// Read the environment variable as a fallback.
+	Address := os.Getenv("TFE_ADDRESS")
+	BasePath := os.Getenv("TFE_BASEPATH")
+
 	// Prepare TFE config.
 	config := &tfe.Config{
 		Token: token,
+		Address: Address,
+		BasePath: BasePath,
 	}
 
 	// Create TFE client.


### PR DESCRIPTION
Needed to support Terraform Enterprise installations

Types of changes
----------------
- New feature (non-breaking change which adds functionality)

Description
-----------
Add parsing of environment variables to support setting Address and BasePath attributes from the TFE Config.

Adds the ability to use the tool against Terraform Enterprise installations, where the Address is not the default.

